### PR TITLE
Fix egregious typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
     <div class="container2"><!--
       <img src="img/cupcakes.jpg" -->
       <div  class="centered">
-      <h1>Bake it 'till you make it</h1>
+      <h1>Bake it till you make it</h1>
       <a href="" class="btn"><button>Order Now</button></a>
     </div>
    </div>


### PR DESCRIPTION
From [this](https://www.merriam-webster.com/words-at-play/should-you-use-until-or-till-or-til) article:

> _’Till_ is entirely shunned by the writers of usage guides, when they see fit to mention it at all. Bryan Garner, in his _Modern American Usage,_ refers to it as “abominable,” which is rather polite when compared to _Harper’s Dictionary of Contemporary Usage,_ which says “the formation _’till_ is a bastard word and is substandard.”